### PR TITLE
すごい広島 #6 に Nyoho 分のリンクを追加

### DIFF
--- a/_posts/2013-6-26-event-006.markdown
+++ b/_posts/2013-6-26-event-006.markdown
@@ -13,3 +13,8 @@ categories: events
 ## [@moriC](https://twitter.com/CentBoss)
 
 * [Sublime Text でRubyのコードを実行する](http://blog.mori-theta.net/?p=172)
+
+## [@NeXTSTEP2OSX](https://twitter.com/NeXTSTEP2OSX)
+
+* [すごい広島 #6 にエア参加した - ワタタツの日記!(2013-06-26)](http://kita.dyndns.org/diary/?date=20130626#p02)
+* [docker に関する誰得系情報 - ワタタツの日記!(2013-06-26)](http://kita.dyndns.org/diary/?date=20130626#p01)


### PR DESCRIPTION
Nyoho 分のリンクを追加しました。すごい広島 #6
#126 とついでに参加したことの日記も書きました。同じページなのにわざわざ2行にしています。
