### PR TITLE
TimeZone の設定と JST であることを明示

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 name: すごい広島
+timezone: Asia/Tokyo
 pygments: true
 permalink: none
 markdown: redcarpet

--- a/_posts/2013-5-22-event-001.markdown
+++ b/_posts/2013-5-22-event-001.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #1"
-date:   2013-05-22 19:00:00
+date:   2013-05-22 19:00:00 JST
 atnd: http://atnd.org/events/39897
 togetter: http://togetter.com/li/507014
 place: tullys_main_street

--- a/_posts/2013-5-29-event-002.markdown
+++ b/_posts/2013-5-29-event-002.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #2"
-date:   2013-05-29 19:00:00
+date:   2013-05-29 19:00:00 JST
 atnd: http://atnd.org/events/39927
 togetter: http://togetter.com/li/510364
 place: tullys_main_street

--- a/_posts/2013-6-01-event-002-5.markdown
+++ b/_posts/2013-6-01-event-002-5.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "すごい広島 #2.5"
-date:   2013-06-01 15:00:00
+date:   2013-06-01 15:00:00 JST
 categories: events
 ---
 

--- a/_posts/2013-6-05-event-003.markdown
+++ b/_posts/2013-6-05-event-003.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #3"
-date:   2013-06-05 19:00:00
+date:   2013-06-05 19:00:00 JST
 atnd: http://atnd.org/events/40132
 togetter: http://togetter.com/li/514216
 place: tullys_main_street

--- a/_posts/2013-6-12-event-004.markdown
+++ b/_posts/2013-6-12-event-004.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #4"
-date:   2013-06-12 19:00:00
+date:   2013-06-12 19:00:00 JST
 atnd: http://atnd.org/events/40366
 togetter: http://togetter.com/li/517809
 place: tullys_main_street

--- a/_posts/2013-6-19-event-005.markdown
+++ b/_posts/2013-6-19-event-005.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "すごい広島 #5"
-date:   2013-06-19 19:00:00
+date:   2013-06-19 19:00:00 JST
 categories: events
 ---
 

--- a/_posts/2013-6-26-event-006.markdown
+++ b/_posts/2013-6-26-event-006.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #6"
-date:   2013-06-26 19:00:00
+date:   2013-06-26 19:00:00 JST
 atnd: http://atnd.org/events/40750
 togetter: http://togetter.com/li/524933
 place: tullys_main_street

--- a/_posts/2013-7-03-event-007.markdown
+++ b/_posts/2013-7-03-event-007.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #7"
-date:   2013-07-03 19:00:00
+date:   2013-07-03 19:00:00 JST
 atnd: http://atnd.org/events/40937
 togetter: http://togetter.com/li/528501
 place: tullys_main_street

--- a/_posts/2013-7-10-event-008.markdown
+++ b/_posts/2013-7-10-event-008.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #8"
-date:   2013-07-10 19:00:00
+date:   2013-07-10 19:00:00 JST
 atnd: http://atnd.org/events/41158
 togetter: http://togetter.com/li/531976
 place: tullys_main_street

--- a/_posts/2013-7-17-event-009.markdown
+++ b/_posts/2013-7-17-event-009.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #9"
-date:   2013-07-17 19:00:00
+date:   2013-07-17 19:00:00 JST
 atnd: http://atnd.org/events/41376
 togetter: http://togetter.com/li/535255
 place: tullys_main_street

--- a/_posts/2013-7-24-event-010.markdown
+++ b/_posts/2013-7-24-event-010.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #10"
-date:   2013-07-24 19:00:00
+date:   2013-07-24 19:00:00 JST
 localsearch: http://local.aguuu.com/events/20463
 togetter: http://togetter.com/li/538687
 place: tullys_main_street

--- a/_posts/2013-7-31-event-011.markdown
+++ b/_posts/2013-7-31-event-011.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #11"
-date:   2013-07-31 19:00:00
+date:   2013-07-31 19:00:00 JST
 localsearch: http://local.aguuu.com/events/20896
 togetter: http://togetter.com/li/542127
 place: tullys_main_street

--- a/_posts/2013-8-07-event-012.markdown
+++ b/_posts/2013-8-07-event-012.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #12"
-date:   2013-08-07 18:30:00
+date:   2013-08-07 18:30:00 JST
 localsearch: http://local.aguuu.com/events/21249
 togetter: http://togetter.com/li/545521
 place: tullys_main_street

--- a/_posts/2013-8-14-event-013.markdown
+++ b/_posts/2013-8-14-event-013.markdown
@@ -1,7 +1,7 @@
 ---
 layout: event
 title:  "すごい広島 #13"
-date:   2013-08-14 18:30:00
+date:   2013-08-14 18:30:00 JST
 localsearch: http://local.aguuu.com/events/21673
 togetter:
 place: tullys_main_street


### PR DESCRIPTION
#203 を修正

_config.yml に timezone の設定ができるらしい。

FrontFormatter (記事の最初にかく YAML の部分) で date をParseして使うみたいなので JST を明示
