### PR TITLE
Corrected a misspelling for Satellite Campus Hiroshima (place information)

### DIFF
--- a/_includes/place
+++ b/_includes/place
@@ -6,7 +6,7 @@
 {% assign place_address = "中区広瀬北町３－１１ 和光広瀬ビル 3F" %}
 {% assign place_name = "ソアラ ビジネスポート セミナールーム" %}
 {% assign place_postcode = "7300803" %}
-{% elsif page.place == "satelight_canpus_hiroshima" %}
+{% elsif page.place == "satellite_campus_hiroshima" %}
 {% assign place_address = "広島県広島市中区大手町１丁目５−３" %}
 {% assign place_name = "サテライトキャンパスひろしま" %}
 {% assign place_postcode = "7300051" %}

--- a/_posts/2013-10-06-event-osc-2013.markdown
+++ b/_posts/2013-10-06-event-osc-2013.markdown
@@ -3,7 +3,7 @@ layout: event
 title:  "すごい広島 in OSC 2013 Hiroshima"
 date:   2013-10-06 10:00:00 JST
 togetter:
-place: satelight_canpus_hiroshima
+place: satellite_campus_hiroshima
 categories: events
 ---
 


### PR DESCRIPTION
サテライトキャンパスひろしまを表す文字列がスペルミスだったので修正しました。
satelight は satellite
canpus は campus 
に直して satelight_canpus_hiroshima を satellite_campus_hiroshima に変更しました。

I corrected a misspelling for Satellite Campus Hiroshima (place information).
Changed the string
from satelight_canpus_hiroshima
to   satellite_campus_hiroshima
