### PR TITLE
「 Issue #327 「 Issue #18 の「githubページの外部へのリンクは「target="_blank"」を指定したいができる...？」を解決する」の実装」のことについてかいた

### DIFF
--- a/_posts/2013-10-09-event-021.markdown
+++ b/_posts/2013-10-09-event-021.markdown
@@ -14,7 +14,12 @@ categories: events
 
 ## [furu](http://twitter.com/pecosantoyobe)
 
-## [松原和也（ゆるふわ系なんとか）](https://twitter.com/Toro_kun)
+## [Toro_kun](https://twitter.com/Toro_kun)
+
+great-h.github.ioサイトから外部へのリンクにtarget=_brankを付けるだけの簡単な作業を行いました。
+
+* [Issue #18](https://github.com/great-h/great-h.github.io/issues/18)
+* [Pull Request](https://github.com/great-h/great-h.github.io/pull/329)
 
 ## [森下智裕](https://github.com/moriC)
 


### PR DESCRIPTION
「 Issue #327 「 Issue #18 の「githubページの外部へのリンクは「target="_blank"」を指定したいができる...？」を解決する」の実装」のことについてかいた

レビューよろしくー
