### PR TITLE
すごい広島#25の日付が間違っていたのでファイル名と中身を修正

### DIFF
--- a/_posts/2013-11-06-event-025.markdown
+++ b/_posts/2013-11-06-event-025.markdown
@@ -1,9 +1,9 @@
 ---
 layout: event
-title: ! 'すごい広島 #25'
-date: 2013-11-05 18:00:00.000000000 +09:00
+title: "すごい広島 #25"
+date: 2013-11-06 18:00:00 JST
 doorkeeper: http://great-h.doorkeeper.jp/events/6912
-togetter: 
+togetter:
 place: city_hiroshima_m-plaza-freespace
 categories: events
 ---


### PR DESCRIPTION
2013/11/6開催予定の日付が誤っているので修正しました。
他にちょっと直してるのは、前回と同じ形式にしてみたかったから。あまり意味はありませぬ。
