### PR TITLE
Update 2014-02-12-event-039.markdown

### DIFF
--- a/_posts/2014-02-12-event-039.markdown
+++ b/_posts/2014-02-12-event-039.markdown
@@ -11,7 +11,9 @@ categories: events
 # 参加者
 
 
-## [enofujityan](http://twitter.com/enofujityan)
+## [fujioenoki](https://github.com/fujioenoki)
+
+* [やること宣言](https://github.com/great-h/great-h.github.io/issues/663)
 
 
 ## [makowis](https://github.com/makowis)
@@ -46,3 +48,4 @@ sitespec はRubyでの開発に馴れてると直感的に使えてよい。
 * [LT駆動開発の事前申し込みページつくった](http://ltdd.doorkeeper.jp/events/9051)
 * [すごい広島のサイトを sitespec に移行しはじめた。](https://github.com/great-h/great-h.github.io/commit/f391fd73fd0cb2421b02ef1440080775f1bf99d9)
 * [すごい広島 #39 に遊びにいった。 - 日常と勉強会と広島と。](http://eielh-life.tumblr.com/post/76431045725/39)
+


### PR DESCRIPTION
#663

下記サイトに沿って実施中です。

Chrome AppsをAndroid/iOSアプリとして動かす方法
http://www.adamrocker.com/blog/342/build-android-ios-app-from-chrome-apps.html

iOSの開発環境はできた。

Androidの開発環境はインストールはできたがPATHの貼り方が不明で調査中です。

まだアプリ実行までには先が長い(-_-;)
