### PR TITLE
Remove the last '/' from self.build_path

### DIFF
--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -5,7 +5,7 @@ require 'pry'
 
 Sitespec.configure do
   self.application = GreatHiroshima::App.new
-  self.build_path = "_site/"
+  self.build_path = "_site"
   self.raise_http_error = true
 end
 


### PR DESCRIPTION
rake したらずらっと [チェック]_site//eventhogehoge と表示されたので
self.build_path は '_site/' ではなく '_site' でいいのかなと
思ったので削除してみた。
これでいいんでしょうか。
