### PR TITLE
すごい hiλoshima 50 - Nyoho 参加記録

### DIFF
--- a/_posts/2014-04-30-event-050.markdown
+++ b/_posts/2014-04-30-event-050.markdown
@@ -81,4 +81,4 @@ doorkeeper に参加登録せずに終わり30分弱で登場してしまいま�
 * [やること宣言](https://github.com/great-h/great-h.github.io/issues/876)
 * [hiλoshima の GitHub Organization](https://github.com/hi-lambda-oshima/)
 * [hiλoshima の GitHub Pages のリポジトリ](https://github.com/hi-lambda-oshima/hi-lambda-oshima.github.io)
-* [hiλohisma の GitHub Pages](http://hi-lambda-oshima.github.io/) まだ single html。hakyll に移行中です。
+* [hiλoshima の GitHub Pages](http://hi-lambda-oshima.github.io/) まだ single html。hakyll に移行中です。


### PR DESCRIPTION
Nyoho のすごい広島 (第50回) の参加記録を追記しました。
念願の hiλoshima の GitHub org を作成することが出来ました。
レビューをお願い申し上げます。
