### PR TITLE
第94回実績報告

### DIFF
--- a/_posts/2015-03-04-event-094.markdown
+++ b/_posts/2015-03-04-event-094.markdown
@@ -22,3 +22,7 @@ categories: events
 
 
 ## [k2works](https://github.com/k2works)
+* [やること宣言](https://github.com/great-h/great-h.github.io/issues/1559)
+* [chefDK-handson](https://github.com/k2works/chefDK-handson)
+  * [ChefSpecが動かない](https://github.com/k2works/chefDK-handson/issues)
+* [タスクの整理](https://huboard.com/parkmap-h/parkmap#/)


### PR DESCRIPTION
パークマッププロジェクトのタスク整理#1562
ChefDKハンズオンを仮想マシン上で仮想マシンを使ってやってみた。
共通の環境を用意することでセミナー・イベントなんかでのWin/Macの違いを吸
収できそう。ハンズオンのうちChefSpecはうまく動かなかったけど調べれば解決
はできそう。